### PR TITLE
Add -t msdos to mount line in script

### DIFF
--- a/usbfd
+++ b/usbfd
@@ -108,7 +108,7 @@ shift $(($OPTIND - 1))
 	  else
 	    mkdir /media/usbfd$FLOP
 	    let MYOFFSET=$OFFSET*$NUM
-	    mount -o loop,offset=$MYOFFSET,users,rw,umask=000 $DEVICE /media/usbfd$FLOP || rmdir /media/usbfd$FLOP 
+	    mount -o loop,offset=$MYOFFSET,users,rw,umask=000 -t msdos $DEVICE /media/usbfd$FLOP || rmdir /media/usbfd$FLOP
 	fi
     done
   ;;


### PR DESCRIPTION
mount -o loop,offset=$MYOFFSET,users,rw,umask=000 -t msdos $DEVICE /media/usbfd$FLOP || rmdir /media/usbfd$FLOP

my computer doesn't discovers the partion type by itself.
